### PR TITLE
Make sure that bwrap dies when sandwine dies

### DIFF
--- a/sandwine/_main.py
+++ b/sandwine/_main.py
@@ -333,6 +333,7 @@ def create_bwrap_argv(config):
 
     argv.add('bwrap')
     argv.add('--new-session')
+    argv.add('--die-with-parent')
 
     # Hostname
     hostname = random_hostname()


### PR DESCRIPTION
.. e.g. when sending `SIGINT` through <kbd>Ctrl</kbd>+<kbd>C</kbd>.