### PR TITLE
Pass --unshare-user to Bubblewrap

### DIFF
--- a/sandwine/_main.py
+++ b/sandwine/_main.py
@@ -233,7 +233,7 @@ def create_bwrap_argv(config):
     ]
     env_tasks = {var: None for var in ['HOME', 'TERM', 'USER', 'WINEDEBUG']}
     env_tasks['container'] = 'sandwine'
-    unshare_args = ['--unshare-all']
+    unshare_args = ['--unshare-user', '--unshare-all']
 
     argv = ArgvBuilder()
 


### PR DESCRIPTION
.. because `--unshare-all` includes `--unshare-user-try` (with emphasis on "try") rather than strict `--unshare-user`.