### PR TITLE
CI: Resolve conflicts with ppa:ubuntu-toolchain-r/test in run-tests.yml

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,11 +39,14 @@ jobs:
         sudo apt-get update
         sudo apt-get install --no-install-recommends --yes -V \
             libcap-dev \
+            ppa-purge \
             python3-pip \
             wget \
-            wine32:i386 \
             xvfb \
             zenity
+        sudo ppa-purge -y ppa:ubuntu-toolchain-r/test  # to unblock
+        sudo apt-get install --no-install-recommends --yes -V \
+            wine32:i386
         pip3 install --ignore-installed build pip setuptools wheel
 
     - name: Build sandwine


### PR DESCRIPTION
Symptom was:
```console
# sudo apt-get install --yes --no-install-recommends -V wine32:i386
[..]
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 libc6:i386 : Depends: libgcc-s1:i386 but it is not going to be installed
 libicu70:i386 : Depends: libgcc-s1:i386 (>= 7) but it is not going to be installed
                 Depends: libstdc++6:i386 (>= 5.2) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

Idea for the fix from https://github.com/actions/runner-images/issues/4589#issuecomment-1549465165, thanks to @ValdikSS :pray: 

Similar to https://github.com/libexpat/libexpat/pull/722 .