### PR TITLE
`run-tests.yml`: Fix for image `ubuntu-22.04` of `20240514.2.0`

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,12 +46,10 @@ jobs:
         sudo apt-get update
         sudo apt-get install --no-install-recommends --yes -V \
             libcap-dev \
-            ppa-purge \
             python3-pip \
             wget \
             xvfb \
             zenity
-        sudo ppa-purge -y ppa:ubuntu-toolchain-r/test  # to unblock
         sudo apt-get install --no-install-recommends --yes -V \
             wine32:i386
         pip3 install --ignore-installed build pip setuptools wheel


### PR DESCRIPTION
Was broken by https://github.com/actions/runner-images/issues/9679 .