### PR TITLE
Correct README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,22 @@ there is some Wine bug at work here.
 ### Run Games (3D applications) with modern stack (Wayland)
 
 ```console
-sandwine --dotwine ~/.wine-games:rw --pass /path/to/Games/folder:rw --wayland --pulseaudio "/path/to/Games/folder/Start.exe"
+sandwine --dotwine ~/".wine-games":rw --pass "/path/to/Games/":rw --wayland --pulseaudio "/path/to/Games/Game Title/Start.exe"
 ```
-`--dotwine ~/.wine-games:rw` is needed to specify persistent Wineprefix. Needed for saves to be stored.
+`--dotwine ~/".wine-games":rw` is needed to specify persistent Wineprefix. Needed for saves/data to be stored.
 
-`--pass /path/to/Games/folder:rw` is used if your Games sit in system storage path.
-If your games are located in Wineprefix like "~/.wine/drive_c/Games", you don't need this parameter.
+`--pass "/path/to/Games/":rw` is used for providing access to storage path.
 
 Optional: `--nvidia-gpu` to enable access to Nvidia GPU.
+
+Since Sandwine prevents usage of `~/.wine` directory as Wineprefix for security reasons, it is recommended to use external folder to run software.
+You can run software from `~/.wine-games` by creating symbolic link to internal Wineprefix folder and use it as external one, by `ln -s ~/".wine-games/drive_c/" ~/"Wine internal software"`
+
+Updated command:
+```console
+sandwine --dotwine ~/".wine-games":rw --pass ~/"Wine internal software/Games/Game Title":rw --wayland --pulseaudio ~/"Wine internal software/Games/Game Title/Start.exe"
+```
+
 
 ### Run Geiss Screensaver: with sound, with host X11 (careful!), no networking, no `~/*` file access
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ is licensed under the "GPL v3 or later" license.
 # Usage Examples
 
 
-### Install Winamp 5.66: no networking, no X11, no sound, no access to `~/*` files
+### Install Winamp 5.66: no networking, no video, no sound, no access to `~/*` files
 
 ```
 # cd ~/Downloads/
@@ -93,7 +93,7 @@ Potentially a bug in Wine, needs more investigation.
 PS: The Geiss Screensaver has its GitHub home at https://github.com/geissomatik/geiss .
 
 
-### Run wget: with networking, no X11, no sound, no access to `~/*` files
+### Run wget: with networking, no video, no sound, no access to `~/*` files
 
 ```console
 # sandwine --network --no-wine -- wget -S -O/dev/null https://blog.hartwork.org/


### PR DESCRIPTION
Since newer versions of Sandwine block usage of ~/.wine, I fixed instructions to add workaround to run programs from Wineprefix. Also changed folder links to use home folder with ~ and demonstrate usage of folders with spaces.

Also replaced "no X11" with "no video" since it supports Wayland and X11

I checked commands in bash and fish, and they are working.