### PR TITLE
Improve `wineserver` command detection (e.g. for Debian sid and Ubuntu 26.04) (fixes #208, alternative to #211 and #212)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ So what is shared with the application by default then?
 - `${USER}`
 - `${WINEDEBUG}`
 - `${WINEDLLOVERRIDES}`
+- `${wineserver}` (lowercase, with the path to command `wineserver`)
 
 
 **sandwine** features include:

--- a/sandwine/_main.py
+++ b/sandwine/_main.py
@@ -23,6 +23,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import sysconfig
 from argparse import ArgumentParser, RawTextHelpFormatter
 from contextlib import nullcontext
 from dataclasses import dataclass
@@ -636,6 +637,9 @@ def which_wineserver() -> str | None:
     extra = [
         os.path.dirname(which_wine()),
     ]
+
+    if (multiarch := sysconfig.get_config_var("MULTIARCH")) is not None:
+        extra.append(f"/usr/lib/{multiarch}/wine")  # e.g. Debian sid and Ubuntu resolute
 
     dollar_path: list[str] = os.pathsep.join(os.environ["PATH"].split(os.pathsep) + extra)
 

--- a/sandwine/_main.py
+++ b/sandwine/_main.py
@@ -551,7 +551,6 @@ def create_bwrap_argv(config):
 
     # Filter ${PATH}
     candidate_paths = os.environ["PATH"].split(os.pathsep)
-    candidate_paths.append("/usr/lib/wine")  # for wineserver on e.g. Debian
     available_paths = []
     for candidate_path in candidate_paths:
         candidate_path = os.path.realpath(candidate_path)
@@ -568,6 +567,7 @@ def create_bwrap_argv(config):
                 ", dropped from ${PATH}."
             )
     env_tasks["PATH"] = os.pathsep.join(available_paths)
+    env_tasks["wineserver"] = which_wineserver()
 
     # Create environment (meaning environment variables)
     argv.add("--clearenv")
@@ -582,7 +582,11 @@ def create_bwrap_argv(config):
 
     # Wrap with wineserver (for clean shutdown, it defaults to 3 seconds timeout)
     if config.with_wine:
-        argv.add("sh", "-c", 'wineserver -p0 && "$0" "$@" ; ret=$? ; wineserver -k ; exit ${ret}')
+        argv.add(
+            "sh",
+            "-c",
+            '"${wineserver}" -p0 && "$0" "$@" ; ret=$? ; "${wineserver}" -k ; exit ${ret}',
+        )
 
     # Add winecfg
     if run_winecfg and config.with_wine:
@@ -597,7 +601,7 @@ def create_bwrap_argv(config):
         # Add Wine
         inner_argv = []
         if config.with_wine:
-            inner_argv.append("wine")
+            inner_argv.append(which_wine())
         inner_argv.append(config.argv_0)
         inner_argv.extend(config.argv_1_plus)
 
@@ -641,7 +645,7 @@ def which_wineserver() -> str | None:
     if (multiarch := sysconfig.get_config_var("MULTIARCH")) is not None:
         extra.append(f"/usr/lib/{multiarch}/wine")  # e.g. Debian sid and Ubuntu resolute
 
-    dollar_path: list[str] = os.pathsep.join(os.environ["PATH"].split(os.pathsep) + extra)
+    dollar_path: list[str] = os.pathsep.join(extra)
 
     return shutil.which("wineserver", path=dollar_path)
 

--- a/sandwine/_main.py
+++ b/sandwine/_main.py
@@ -622,8 +622,35 @@ def require_recent_bubblewrap():
         sys.exit(1)
 
 
+def which_wine() -> str | None:
+    extra = [
+        "/usr/lib/wine",  # Debian trixie (and earlier), Ubuntu questing (and earlier)
+    ]
+
+    dollar_path: list[str] = os.pathsep.join(os.environ["PATH"].split(os.pathsep) + extra)
+
+    return shutil.which("wine", path=dollar_path)
+
+
+def which_wineserver() -> str | None:
+    extra = [
+        os.path.dirname(which_wine()),
+    ]
+
+    dollar_path: list[str] = os.pathsep.join(os.environ["PATH"].split(os.pathsep) + extra)
+
+    return shutil.which("wineserver", path=dollar_path)
+
+
 def require_command_available(command: str):
-    if shutil.which(command) is None:
+    if command == "wine":
+        resolved = which_wine()
+    elif command == "wineserver":
+        resolved = which_wineserver()
+    else:
+        resolved = shutil.which(command)
+
+    if resolved is None:
         raise CommandNotFound(command)
 
 
@@ -643,6 +670,10 @@ def _inner_main(with_wine: bool):
             require_command_available("script")
 
         require_recent_bubblewrap()
+
+        if with_wine:
+            require_command_available("wine")
+            require_command_available("wineserver")
 
         if X11Mode(config.x11) != X11Mode.NONE:
             if X11Mode(config.x11) == X11Mode.AUTO:


### PR DESCRIPTION
Fixes #208, alternative to #211 and #212