### PR TITLE
Add `/dev/nvidia-uvm` file mount task

### DIFF
--- a/sandwine/_main.py
+++ b/sandwine/_main.py
@@ -410,6 +410,7 @@ def create_bwrap_argv(config):
             MountTask(MountMode.BIND_DEV, "/dev/nvidia0"),
             MountTask(MountMode.BIND_DEV, "/dev/nvidiactl"),
             MountTask(MountMode.BIND_DEV, "/dev/nvidia-modeset"),
+            MountTask(MountMode.BIND_DEV, "/dev/nvidia-uvm"),
         ]
 
     # Input


### PR DESCRIPTION
Fixes https://github.com/hartwork/sandwine/issues/47#issuecomment-4698882891
It seems existing paths are not enough for some games to run.