### PR TITLE
wine *.lnk, wine start: prevent process is killed (fixes #215)

### DIFF
--- a/sandwine/_main.py
+++ b/sandwine/_main.py
@@ -613,10 +613,16 @@ def create_bwrap_argv(config):
         parts = [
             '"$0" "$@"',
             "ret=$?",
-            '"${wineserver}" -k ' + str(signal.SIGTERM),
-            '"${wineserver}" -w',
-            "exit ${ret}",
         ]
+        if (config.argv_0.casefold() != "start") and not config.argv_0.casefold().endswith(".lnk"):
+            # make the wineserver exit faster.
+            parts.append('"${wineserver}" -k ' + str(signal.SIGTERM))
+        parts.extend(
+            [
+                '"${wineserver}" -w',
+                "exit ${ret}",
+            ]
+        )
         argv.add("sh", "-c", " ; ".join(parts))
 
     # Add winecfg


### PR DESCRIPTION
Both `wine start` and `wine *.lnk launch a process and exit before that process has terminated. Do not kill the wineserver, but wait for the wineserver to exit spontaneously to be sure the launched process has terminated. Otherwise, the process will be killed before it has terminated.

The script tool was in the way for this to work properly, and the ioctl(TIOCSTI) vulnerability has been eliminated in kernel 6.2, so script is no longer required.

This solves https://github.com/hartwork/sandwine/issues/215.